### PR TITLE
Fix the travis build error

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     },
     "require": {
         "beberlei/assert": "~2.0",
-        "php": ">=5.5"
+        "php": ">=5.4"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0"


### PR DESCRIPTION
Travis tests against php 5.4 because it is defined in the yml file.
